### PR TITLE
Ensure that the AuthCode gets set correctly.

### DIFF
--- a/GoogleSignInPlugin/Assets/GoogleSignIn/Impl/NativeFuture.cs
+++ b/GoogleSignInPlugin/Assets/GoogleSignIn/Impl/NativeFuture.cs
@@ -65,6 +65,10 @@ namespace Google.Impl {
               GoogleSignInImpl.GoogleSignIn_GetIdToken(userPtr, out_string,
                                                        out_size));
 
+          user.AuthCode = OutParamsToString((out_string, out_size) =>
+              GoogleSignInImpl.GoogleSignIn_GetServerAuthCode(userPtr, out_string,
+                                                              out_size));
+
           string url = OutParamsToString((out_string, out_size) =>
               GoogleSignInImpl.GoogleSignIn_GetImageUrl(userPtr, out_string,
                                                         out_size));


### PR DESCRIPTION
This fixes a bug where the AuthCode will always be `null` even when `RequestAuthCode` is enabled in the global configuration. Tested in an app built with Unity 2017 on a real iOS device.