### PR TITLE
Fix Issue #12 Android google signin crash when add AdditionalScopes i…

### DIFF
--- a/native-googlesignin/src/main/cpp/google_signin.cc
+++ b/native-googlesignin/src/main/cpp/google_signin.cc
@@ -234,7 +234,7 @@ void GoogleSignIn::GoogleSignInImpl::Configure(
   delete current_result_;
   current_result_ = new GoogleSignInFuture();
 
-  CallConfigure();
+  //CallConfigure();
 }
 
 void GoogleSignIn::GoogleSignInImpl::CallConfigure() {


### PR DESCRIPTION
When you call CallConfigure() on line 237 and then again on either SignIn() (L302) or SignInSilently() (L318) the value of current_configuration_->additional_scopes() (L267) seems to be gone/wrongly adjust the second time it is being read while it is actually a const char* which is odd. 

This fixes the crash but I assume there is something else going wrong which causes the value of additional_scopes being adjusted. So it might require some better research to track that one down. 