### PR TITLE
Add arm64-v8a for libnative-googlesignin.so

### DIFF
--- a/native-googlesignin/build.gradle
+++ b/native-googlesignin/build.gradle
@@ -45,7 +45,7 @@ android {
             }
         }
         ndk {
-            abiFilters 'x86', 'armeabi-v7a'
+            abiFilters 'x86', 'armeabi-v7a', 'arm64-v8a'
         }
     }
     lintOptions {

--- a/staging/native/build.gradle
+++ b/staging/native/build.gradle
@@ -58,7 +58,7 @@ android {
             }
         }
         ndk {
-            abiFilters 'x86', 'armeabi-v7a'
+            abiFilters 'x86', 'armeabi-v7a', 'arm64-v8a'
         }
     }
     lintOptions {


### PR DESCRIPTION
From Unity 2018.2, you can build app with arm64-v8a support. When I do this, I got an error of `DllNotFoundException: native-googlesignin` and nothing worked. I build by myself and confirmed that this will fix the issue.