### PR TITLE
Handle RESULT_CANCELED at onActivityResult to detect user cancel

### DIFF
--- a/native-googlesignin/src/main/java/com/google/googlesignin/GoogleSignInFragment.java
+++ b/native-googlesignin/src/main/java/com/google/googlesignin/GoogleSignInFragment.java
@@ -527,7 +527,11 @@ public class GoogleSignInFragment extends Fragment implements
       TokenRequest request = this.request;
       if (request != null) {
         GoogleSignInAccount acct = result.getSignInAccount();
-        request.setResult(result.getStatus().getStatusCode(), acct);
+        if (resultCode == Activity.RESULT_CANCELED) {
+          request.setResult(CommonStatusCodes.CANCELED, acct);
+        } else {
+          request.setResult(result.getStatus().getStatusCode(), acct);
+        }
       } else {
         GoogleSignInHelper.logError("Pending request is null, can't " + "return result!");
       }


### PR DESCRIPTION
On android, if I cancel sign in dialog by tapping outside of the box, it will return SignInException with status of `Error`. This PR will fix this issue and it will return status of `Cancel`.
I think this is related to #53.