### PR TITLE
Handle RESULT_CANCELED at onActivityResult to detect user cancel

### DIFF
--- a/native-googlesignin/src/main/java/com/google/googlesignin/GoogleSignInFragment.java
+++ b/native-googlesignin/src/main/java/com/google/googlesignin/GoogleSignInFragment.java
@@ -533,7 +533,11 @@ public class GoogleSignInFragment extends Fragment implements
           GoogleSignInHelper.logError("GoogleSignIn result is null, returning error.");
         } else {
           GoogleSignInAccount acct = result.getSignInAccount();
-          request.setResult(result.getStatus().getStatusCode(), acct);
+          if (resultCode == Activity.RESULT_CANCELED) {
+            request.setResult(CommonStatusCodes.CANCELED, acct);
+          } else {
+            request.setResult(result.getStatus().getStatusCode(), acct);
+          }
         }
       } else {
         GoogleSignInHelper.logError("Pending request is null, can't " + "return result!");


### PR DESCRIPTION
This fixes the error that occurred when you canceled the login process by clicking the "Back" button on your phone on Android or by pressing outside the account selection box. The error was that instead of detecting that action as task.IsCanceled, it was detected as task.IsFaulted and left an error. In my case the error was something like: GoogleSignIn+Exception.SignIn.